### PR TITLE
Improve permissions adjustment logic with privilege elevation fallback

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -1,9 +1,7 @@
+# Ensure that Docker is running, otherwise exit
 docker info > /dev/null 2>&1
-
-# Ensure that Docker is running...
 if [ $? -ne 0 ]; then
-    echo "Docker is not running."
-
+    echo "Docker is not running. Exiting."
     exit 1
 fi
 
@@ -16,7 +14,7 @@ docker run --rm \
 
 cd {{ name }}
 
-# Allow build with no additional services..
+# Allow build with no additional services
 if [ "{{ services }}" == "none" ]; then
     ./vendor/bin/sail build
 else
@@ -31,22 +29,36 @@ NC='\033[0m'
 
 echo ""
 
-if command -v doas &>/dev/null; then
-    SUDO="doas"
-elif command -v sudo &>/dev/null; then
-    SUDO="sudo"
-else
-    echo "Neither sudo nor doas is available. Exiting."
-    exit 1
+# Attempt to adjust permissions without privilege elevation
+if ! chown -R "$USER": . 2>/dev/null; then
+    CHOWN_ERROR=true
+
+    # Check for privilege elevation tools (doas or sudo)
+    if command -v doas &>/dev/null; then
+        SUDO="doas"
+    elif command -v sudo &>/dev/null; then
+        SUDO="sudo"
+    else
+        SUDO=""
+    fi
+
+    # Attempt to adjust permissions with privilege elevation
+    if [ -n "$SUDO" ]; then
+        echo -e "${BOLD}Attempting to adjust permissions with elevated privileges.${NC}"
+        echo -e "${BOLD}Please provide your password so we can make some final adjustments to your application's permissions.${NC}"
+        echo ""
+        if $SUDO chown -R "$USER": . 2>/dev/null; then
+            CHOWN_ERROR=false
+        fi
+    fi
+
+    # If applicable, print permissions adjustment error and exit
+    if [ "$CHOWN_ERROR" = true ]; then
+        echo -e "${BOLD}Failed to adjust permissions.${NC}"
+        echo -e "${BOLD}You can still try running the application. It might work without adjusted permissions.${NC}"
+        exit 2
+    fi
 fi
 
-if $SUDO -n true 2>/dev/null; then
-    $SUDO chown -R $USER: .
-    echo -e "${BOLD}Get started with:${NC} cd {{ name }} && ./vendor/bin/sail up"
-else
-    echo -e "${BOLD}Please provide your password so we can make some final adjustments to your application's permissions.${NC}"
-    echo ""
-    $SUDO chown -R $USER: .
-    echo ""
-    echo -e "${BOLD}Thank you! We hope you build something incredible. Dive in with:${NC} cd {{ name }} && ./vendor/bin/sail up"
-fi
+echo -e "${BOLD}All done! We hope you build something incredible. Get started with:${NC} cd {{ name }} && ./vendor/bin/sail up"
+exit 0


### PR DESCRIPTION
- First, attempts permissions adjustment without elevated privileges
- Fallback to privilege elevation tools (`sudo` or `doas`) if available
- If applicable, print permissions adjustment error and guide user